### PR TITLE
Update YAML loader to SafeLoader

### DIFF
--- a/bin/archutil
+++ b/bin/archutil
@@ -314,7 +314,7 @@ def main():
 
     global config
     config = {}
-    config_yaml = yaml.load(open(config_file_path, 'r'))
+    config_yaml = yaml.load(open(config_file_path, 'r'), Loader=yaml.SafeLoader)
 
     if 'pacman' in config_yaml:
         config['pacman'] = config_yaml['pacman']


### PR DESCRIPTION
The default YAML loader is expolitable and causes a warning everytime
that archutil runs. This changes the loader to SafeLoader to remove
the warning and remove the exploit.